### PR TITLE
Add minimal setup for Native Packager

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,21 @@ Furthermore, the console provides a JSON API described in [RAML](/public/api-con
 
 Requirements
 ---
-- Play Framework 2.2.x
+- Play Framework 2.3.x
 - Apache Kafka 0.8.x
 - Zookeeper 3.3.3 or 3.3.4
 
 Deployment
 ----
-Consult Play!'s documentation for [deployment options and instructions](http://www.playframework.com/documentation/2.2.x/Production).
+Consult Play!'s documentation for [deployment options and instructions](http://www.playframework.com/documentation/2.3.x/Production).
+
+For instance, build a Debian package with the `debian:packageBin` task in SBT. You'll need to supply a production configuration file at `/etc/kafka-web-console/production.conf` after installing the produced .deb---you may copy `conf/application.conf` from the repo to start with, just change the secret key! Also if you stick with an H2 database, locate the file someplace that the `kafka-web-console` user has write privileges for, such as:
+
+    db.default.url="jdbc:h2:file:/var/run/kafka-web-console/play"
 
 Getting Started
 ---
-1. Kafka Web Console requires a relational database. By default, the server connects to an embedded H2 database and no database installation or configuration is needed. Consult Play!'s documentation to [specify a database for the console](http://www.playframework.com/documentation/2.2.x/ScalaDatabase). The following databases are supported:
+1. Kafka Web Console requires a relational database. By default, the server connects to an embedded H2 database and no database installation or configuration is needed. Consult Play!'s documentation to [specify a database for the console](http://www.playframework.com/documentation/2.3.x/ScalaDatabase). The following databases are supported:
    - H2 (default)
    - PostgreSql
    - Oracle

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ name := "kafka-web-console"
 
 version := "2.1.0-SNAPSHOT"
 
+scalaVersion := "2.10.4"
+
 libraryDependencies ++= Seq(
   jdbc,
   cache,
@@ -15,4 +17,29 @@ libraryDependencies ++= Seq(
     exclude("com.sun.jmx", "jmxri")
 )
 
-play.Project.playScalaSettings
+enablePlugins(PlayScala, SbtWeb)
+
+includeFilter in (Assets, LessKeys.less) := "custom.less"
+
+/*
+ * Basic metadata for building native packages
+ *
+ * https://www.playframework.com/documentation/2.3.x/ProductionDist#The-Native-Packager
+ *
+ * - Run `sbt stage`
+ * - Inspect target/universal/stage
+ * - Run e.g. `sbt debian:packageBin`
+ */
+import com.typesafe.sbt.SbtNativePackager._
+import NativePackagerKeys._
+
+maintainer := "Claude Mamo <claude.mamo@gmail.com>"
+
+packageSummary := "A web application for monitoring Apache Kafka"
+
+packageDescription := packageSummary.value
+
+daemonUser in Linux := normalizedName.value
+
+daemonGroup in Linux := (daemonUser in Linux).value
+

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,9 @@
 logLevel := Level.Warn
 
 // The Typesafe repository 
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.2.1")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.8")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.6")

--- a/src/templates/etc-default
+++ b/src/templates/etc-default
@@ -1,0 +1,13 @@
+# When building native packages, SBT Native Packager will install this file
+# to /etc/default and the app start script will include its contents in the
+# start command.
+#
+# See: http://www.scala-sbt.org/sbt-native-packager/topics/play.html
+
+# Tell Play where to keep its pidfile
+-Dpidfile.path=/var/run/${{app_name}}/play.pid
+
+-DapplyEvolutions.default=true
+
+# Deployers should place their own config file with their own secret key
+-Dconfig.file=/etc/${{app_name}}/production.conf


### PR DESCRIPTION
Play includes SBT Native Packager, but it won't work without at least some minimal metadata filled in the build configuration. This adds enough to produce a working Debian package with the `debian:packageBin` task. The `universal:packageBin` task should also work to produce a zipball containing built jars and run scripts.

Upgraded to Play 2.3 because from what I could tell, the version of Native Packager in 2.2 did not support the [Java Server Application archetype][1], the desirable way to deploy a utility service like this which is the default in Play 2.3 settings. This required adding the sbt-less plugin since [asset stuff has now been modularized][2].

[1]: http://www.scala-sbt.org/sbt-native-packager/archetypes/java_server/index.html
[2]: https://www.playframework.com/documentation/2.3.x/Migration23